### PR TITLE
Fix remaining Shapeless 2.1 issues

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -15,7 +15,7 @@ object Build extends Build {
   // -------------------------------------------------------------------------------------------------------------------
 
   lazy val root = Project("root",file("."))
-    .aggregate(examples, sprayCaching, sprayCan, sprayCanTests, sprayClient, sprayHttp, sprayHttpx,
+    .aggregate(docs, examples, sprayCaching, sprayCan, sprayCanTests, sprayClient, sprayHttp, sprayHttpx,
       sprayIO, sprayIOTests, sprayRouting, sprayRoutingShapeless2, sprayRoutingTests, sprayRoutingShapeless2Tests, sprayServlet, sprayTestKit, sprayUtil)
     .settings(basicSettings: _*)
     .settings(noPublishing: _*)
@@ -213,6 +213,11 @@ object Build extends Build {
     .settings(SphinxSupport.settings: _*)
     .settings(docsSettings: _*)
     .settings(libraryDependencies ++= test(akkaActor, sprayJson), addSpecs2("test")) // , json4sNative))
+    .settings(
+      libraryDependencies ++= {
+        if (scalaBinaryVersion.value startsWith "2.10") Seq(compilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)) else Nil
+      }
+    )
 
 
   // -------------------------------------------------------------------------------------------------------------------

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -15,7 +15,7 @@ object Build extends Build {
   // -------------------------------------------------------------------------------------------------------------------
 
   lazy val root = Project("root",file("."))
-    .aggregate(docs, examples, sprayCaching, sprayCan, sprayCanTests, sprayClient, sprayHttp, sprayHttpx,
+    .aggregate(examples, sprayCaching, sprayCan, sprayCanTests, sprayClient, sprayHttp, sprayHttpx,
       sprayIO, sprayIOTests, sprayRouting, sprayRoutingShapeless2, sprayRoutingTests, sprayRoutingShapeless2Tests, sprayServlet, sprayTestKit, sprayUtil)
     .settings(basicSettings: _*)
     .settings(noPublishing: _*)
@@ -141,6 +141,9 @@ object Build extends Build {
             val isExcluded = sourceWithShapeless2Changes(f.getName.toLowerCase)
             !(isExcluded && f.getAbsolutePath.contains("spray-routing/"))
           }
+        },
+        libraryDependencies ++= {
+          if (scalaBinaryVersion.value startsWith "2.10") Seq(compilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)) else Nil
         }
       )
 
@@ -160,7 +163,10 @@ object Build extends Build {
       .dependsOn(sprayRoutingShapeless2)
       .settings(
         unmanagedResourceDirectories in Test <++= (unmanagedResourceDirectories in Test in sprayRoutingTests),
-        unmanagedSourceDirectories in Test <<= (unmanagedSourceDirectories in Test in sprayRoutingTests)
+        unmanagedSourceDirectories in Test <<= (unmanagedSourceDirectories in Test in sprayRoutingTests),
+        libraryDependencies ++= {
+          if (scalaBinaryVersion.value startsWith "2.10") Seq(compilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)) else Nil
+        }
       )
 
   lazy val sprayServlet = Project("spray-servlet", file("spray-servlet"))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -48,7 +48,7 @@ object Dependencies {
   }
 
   val addScalaReflect = libraryDependencies <+= scalaVersion("org.scala-lang" % "scala-reflect" % _ % "provided")
-  def addSpecs2(config: String) = libraryDependencies <+= scalaVersion(version => "org.specs2" %% "specs2" % specs2VersionPerScala(version) % config)
+  def addSpecs2(config: String) = libraryDependencies <+= scalaVersion(version => "org.specs2" %% "specs2" % specs2VersionPerScala(version) % config exclude ("org.scalamacros", "quasiquotes_2.10.3"))
 
   def specs2VersionPerScala(version: String): String = CrossVersion.partialVersion(version) match {
     case Some((2, 11)) => "2.3.13"

--- a/spray-routing-shapeless2/src/main/scala/spray/routing/directives/Shapeless2Support.scala
+++ b/spray-routing-shapeless2/src/main/scala/spray/routing/directives/Shapeless2Support.scala
@@ -23,6 +23,14 @@ object AnyParamDefMagnet2 {
       }
     }
 
+  implicit def forIdentityHList[L <: HList](implicit f: LeftFolder[L, Directive0, MapReduce.type]) =
+    new AnyParamDefMagnet2[L] {
+      type Out = f.Out
+      def apply(value: L) = {
+        value.foldLeft(BasicDirectives.noop)(MapReduce)
+      }
+    }
+
   object MapReduce extends Poly2 {
     implicit def from[T, LA <: HList, LB <: HList, Out <: HList](implicit fdma: FieldDefMagnetAux[T, Directive[LB]],
                                                                  pdma: ParamDefMagnetAux[T, Directive[LB]],
@@ -51,6 +59,9 @@ trait LowLevelFieldDefMagnet2 {
 
   implicit def forHList[T, L <: HList](implicit hla: Generic.Aux[T, L], f: LeftFolder[L, Directive0, MapReduce.type]) =
     FieldDefMagnetAux[T, f.Out](t ⇒ hla.to(t).foldLeft(BasicDirectives.noop)(MapReduce))
+
+  implicit def forIdentityHList[L <: HList](implicit f: LeftFolder[L, Directive0, MapReduce.type]) =
+    FieldDefMagnetAux[L, f.Out](t ⇒ t.foldLeft(BasicDirectives.noop)(MapReduce))
 
   object MapReduce extends Poly2 {
     implicit def from[T, LA <: HList, LB <: HList, Out <: HList](implicit fdma: FieldDefMagnetAux[T, Directive[LB]], ev: Prepend.Aux[LA, LB, Out]) =
@@ -120,6 +131,9 @@ trait LowLevelParamDefMagnet2 {
   /************ HList/tuple support ******************/
   implicit def forHList[T, L <: HList](implicit hla: Generic.Aux[T, L], f: LeftFolder[L, Directive0, MapReduce.type]) =
     ParamDefMagnetAux[T, f.Out](t ⇒ hla.to(t).foldLeft(BasicDirectives.noop)(MapReduce))
+
+  implicit def forIdentityHList[L <: HList](implicit f: LeftFolder[L, Directive0, MapReduce.type]) =
+    ParamDefMagnetAux[L, f.Out](l ⇒ l.foldLeft(BasicDirectives.noop)(MapReduce))
 
   object MapReduce extends Poly2 {
     implicit def from[T, LA <: HList, LB <: HList, Out <: HList](implicit pdma: ParamDefMagnetAux[T, Directive[LB]], ev: Prepend.Aux[LA, LB, Out]) =


### PR DESCRIPTION
Scala 2.10 compilation had a few issues -- conflicting quasiquotes dependency between Shapeless and specs2 and missing macro paradise compiler plugin.

The removal of `Generic.Aux[L, L] forSome { type L <: HList }` caused the other problems. These were fixed by introducing additional implicit witnesses for each impacted magnet.

Docs aren't building so that project was disabled.
